### PR TITLE
Update linux-i2c-dev.h

### DIFF
--- a/linux-i2c-dev.h
+++ b/linux-i2c-dev.h
@@ -23,6 +23,7 @@
 #ifndef LIB_I2CDEV_H
 #define LIB_I2CDEV_H
 
+#include <stddef.h>
 #include <linux/types.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
LLVM-based C compilers need NULL explicitly defined, in stddef.h.
